### PR TITLE
Move dotfiles from APP_BASE

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -23,9 +23,10 @@ APP_DEPS=$(cat ${ENV_DIR}/APP_DEPS)       # ex. `api core`
 
 (
     stage=`mktemp -d`                                                          && # make a temp directory to stage "correct" layout
+    shopt -s dotglob                                                           && # include files that start with .
     mv ${BUILD_DIR}/${APP_BASE}/* ${stage}                                     && # stage the app folder we care about
     for app_dir in ${APP_DEPS}; do mv ${BUILD_DIR}/${app_dir} ${stage}; done   && # stage the dependency folders we also care about
-    shopt -s dotglob nullglob                                                  && # include files that start with . and resolve missing patterns to null
+    shopt -s nullglob                                                          && # resolve missing patterns to null
     rm -rf ${BUILD_DIR}/*                                                      && # clean the target
     mv ${stage}/* ${BUILD_DIR}/
 )


### PR DESCRIPTION
At the moment files such as `${APP_BASE}/.file` aren't moved into the root of the project. This can cause build failures if those files are required.